### PR TITLE
Build locally first before deploying

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+ci/
+Procfile
+docker-compose*
+.nvmrc

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 node_modules
 /dist
 
-
 # local env files
 .env.local
 .env.*.local

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ docker:
 up:
 	docker-compose up -d
 
+.PHONY: scale-worker
+scale-worker:
+	docker-compose up --scale=$(NUM_WORKERS)
+
 .PHONY: down
 down:
 	docker-compose down

--- a/README.md
+++ b/README.md
@@ -85,16 +85,31 @@ create an inventory file. A sample inventory file has been provided in
 `ci/ansible/inventory`.
 
 - Set the SSH user, password, ans herbert_version in the [all:vars] section
-    - If you want to deploy a local version of herbert, set
-      `herbert_version=local`
-- Add IPs / hosts for databases
+- Add hosts for databases
     - Set vars listed under [databases:vars]
-- Add IPs / hosts for servers
-    - Set the vars listed under [servers:vars]
-- Add IPs / hosts for clients
-    - Set the vars listed under [clients:vars]
-- Add IPs / hosts for workers
-    - Set config_path and config_name per worker IP
+
+## Deployment Version
+
+Deployment is performed using the `ci/Makefile` and `make` command. To choose
+the version of hebert to deploy, you must set the `HERBERT_BRANCH` var. See
+examples below.
+
+```bash
+# deploy tagged version 0.18.0
+cd ci && make deploy-all HERBERT_BRANCH=0.18.0
+
+# deploy main branch to only workers
+cd ci && make deploy-workers HERBERT_BRANCH=main
+
+# deploy local changes in current working directory to only servers
+cd ci && make deploy-servers HERBERT_BRANCH=local
+
+# deploy develop branch to only clients
+cd ci && make deploy-clients HERBERT_BRANCH=develop
+
+# deploy to only databases (No need to set HERBERT_BRANCH here)
+cd ci && make deploy-databases
+```
 
 ## Database Deployment
 
@@ -102,10 +117,10 @@ Using Raspberry Pi 3 Model A+ & Raspberry Pi OS Lite 5.10 2021-05-07
 
 - Image database using `scripts/reimage.sh` script
 - Update `ci/ansible/inventory`
-    - Add database IP under `[databases]` section
+    - Add database hosts under `[databases]` section
     - Set vars under `[databases:vars]` section
 - Run ansible databases deployment
-    - `cd ci/ansible && ansible-playbook -i inventory database.yml`
+    - `cd ci && make deploy-databases`
 
 ## Server Deployment
 
@@ -113,23 +128,19 @@ Using Raspberry Pi 3 Model A+ & Raspberry Pi OS Lite 5.10 2021-05-07
 
 - Image server using `scripts/reimage.sh` script
 - Update `ci/ansible/inventory`
-    - Add server IP under `[servers]` section
-    - Set vars under `[servers:vars]` section
+    - Add server hosts under `[servers]` section
 - Run ansible servers deployment
-    - `cd ci/ansible && ansible-playbook -i inventory server.yml`
+    - `cd ci && make deploy-servers HERBERT_BRANCH=<branch_or_tag>`
 
 ## Worker Deployment
 
 Using Raspberry Pi 3 Model A+ & Raspberry Pi OS Lite 5.10 2021-05-07
 
 - Image worker using `scripts/reimage.sh` script
-- Create configuration json file for worker
 - Update `ci/ansible/inventory`
-    - Add worker IP under `[workers]` section
-    - Set `config_path` and `config_name` for this worker
-    - Set vars under `[workers:vars]` section
+    - Add worker hosts under `[workers]` section
 - Run ansible workers deployment
-    - `cd ci/ansible && ansible-playbook -i inventory worker.yml`
+    - `cd ci && make deploy-workers HERBERT_BRANCH=<branch_or_tag>`
 
 Deploying to a single worker via ansible can be accomplished via the following:
 
@@ -138,19 +149,15 @@ cd ci/ansible
 ansible-playbook --limit <target_worker_host_ip> worker.yml
 ```
 
-TODO: In the future we can probably use a jinja2 template for configs similar
-to what we are doing for service definition files now
-
 ## Client Deployment
 
 Using Raspberry Pi 3 Model A+ & Raspberry Pi OS Lite 5.10 2021-05-07
 
 - Image client using `scripts/reimage.sh` script
 - Update `ci/ansible/inventory`
-    - Add client IP under `[clients]` section
-    - Set vars under `[clients:vars]` section
+    - Add client hosts under `[clients]` section
 - Run ansible clients deployment
-    - `cd ci/ansible && ansible-playbook -i inventory client.yml`
+    - `cd ci && make deploy-clients HERBERT_BRANCH=<branch_or_tag>`
 
 ## Deployment Logs
 Logs for production deployments are all managed by journald. Each service's
@@ -178,6 +185,13 @@ Bring up all containers
 make docker
 make up
 # Then navigate to http://localhost:8080 in your browser
+```
+
+Scale up workers
+
+```bash
+# Create 3 worker containers
+make scale-workers NUM_WORKERS=3
 ```
 
 Tear down all containers

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,0 +1,42 @@
+.PHONY: all
+all: deploy-all
+
+.PHONY: check_branch
+check_branch:
+ifeq ($(HERBERT_BRANCH),)
+	@echo ""
+	@echo "Must set HERBERT_BRANCH. Use \"local\" to deploy current changes,"
+	@echo "or use a tag version to deploy a release."
+	@echo ""
+	@exit 1
+endif
+
+.PHONY: deploy-all
+deploy-all: deploy-databases deploy-servers deploy-workers deploy-clients
+
+.PHONY: build
+build: check_branch
+	./build.sh $(SERVICE) $(HERBERT_BRANCH)
+
+.PHONY: deploy
+deploy:
+	ansible-playbook -i ansible/inventory ansible/$(SERVICE).yml
+
+.PHONY: deploy-databases
+deploy-databases:
+	$(MAKE) deploy SERVICE=database
+
+.PHONY: deploy-servers
+deploy-servers:
+	$(MAKE) build SERVICE=server
+	$(MAKE) deploy SERVICE=server
+
+.PHONY: deploy-clients
+deploy-clients:
+	$(MAKE) build SERVICE=client
+	$(MAKE) deploy SERVICE=client
+
+.PHONY: deploy-workers
+deploy-workers:
+	$(MAKE) build SERVICE=worker
+	$(MAKE) deploy SERVICE=worker

--- a/ci/ansible/client.yml
+++ b/ci/ansible/client.yml
@@ -1,46 +1,57 @@
 - hosts: clients
-  become: yes
 
   vars:
-    - buildDir: "/etc/opt"
-    - appDir: "{{ buildDir }}/herbert"
-    - nodejs_version: "14.x"
-    - nodejs_package_json_path: "{{appDir}}"
-    - service_description: "Herbert client dashboard service"
+    - nodejs_version: '14.x'
+    - service_description: 'Herbert client dashboard service'
     - service_user: root
     - service_file: index.js
 
   tasks:
-    - name: Git Clone Repo
-      become: no
-      when: herbert_version != "local"
-      git:
-        repo: https://github.com/metatooth/herbert.git
-        dest: "{{appDir}}"
-        version: "{{herbert_version}}"
-        force: yes
+    - name: Create {{ appDir }}
+      file:
+        path: '{{ appDir }}'
+        state: directory
 
-    - name: Sync local herbert repo
-      become: no
-      when: herbert_version == "local"
+    - name: Create {{ appDir }}/dist
+      file:
+        path: '{{ appDir }}/dist'
+        state: directory
+
+    - name: Sync herbert dist
       synchronize:
-        src: ../../../herbert
-        dest: "{{buildDir}}"
+        src: '{{ distDir }}/client'
+        dest: '{{ appDir }}/dist'
+        recursive: yes
+        delete: yes
 
-    - name: Install nodejs {{nodejs_version}} and node_modules
-      when: herbert_version != "local"
+    - name: Sync index.js
+      synchronize:
+        src: '{{ srcDir }}/index.js'
+        dest: '{{ appDir }}'
+
+    - name: Sync herbert package.json
+      synchronize:
+        src: '{{ srcDir }}/package.json'
+        dest: '{{ appDir }}'
+
+    - name: Sync herbert package-lock.json
+      synchronize:
+        src: '{{ srcDir }}/package-lock.json'
+        dest: '{{ appDir }}'
+
+    - name: Install nodejs {{nodejs_version}}
       include_role:
         name: geerlingguy.nodejs
 
-    - name: Build client
-      become: no
-      when: herbert_version != "local"
-      command: "chdir={{appDir}} npm run build:client"
+    - name: Install production node_modules
+      command: npm install
+      args:
+        chdir: '{{ appDir }}'
       environment:
-        VUE_APP_WS_URL: "ws://{{api_host}}:{{api_port}}"
-        VUE_APP_API_URL: "http://{{api_host}}:{{api_port}}"
+        NODE_ENV: production
 
     - name: Install client service
+      become: yes
       template:
         src: ./templates/systemd-service.j2
         dest: /etc/systemd/system/herbert-client.service
@@ -49,6 +60,7 @@
         mode: '0644'
 
     - name: Enable and start herbert-client service
+      become: yes
       systemd:
         name: herbert-client
         state: restarted

--- a/ci/ansible/inventory.sample
+++ b/ci/ansible/inventory.sample
@@ -3,7 +3,10 @@ ansible_connection=ssh
 ansible_user=<add_ssh_user>
 ansible_ssh_pass=<add_ssh_password>
 ansible_python_interpreter=/usr/bin/python3
-herbert_version=<version_of_herbert_to_deploy>
+buildDir="/home/{{ ansible_user }}"
+appDir="{{ buildDir }}/herbert"
+srcDir=/tmp/herbert/deployment
+distDir="{{ srcDir }}/dist"
 
 [databases]
 <add_db_hosts>
@@ -18,17 +21,21 @@ db_allowed_cidr=<add_allowed_cidr>
 <add_server_hosts>
 
 [servers:vars]
-dburl=postgresql://<dbuser>:<dbpass>@<db_ip>:5432/<dbname>
+dbuser="{{ hostvars[groups['databases'][0]].dbuser }}"
+dbpass="{{ hostvars[groups['databases'][0]].dbpass }}"
+dbname="{{ hostvars[groups['databases'][0]].dbname }}"
+dbhost="{{ groups['databases'][0] }}"
+dburl="postgresql://{{ dbuser }}:{{ dbpass }}@{{ dbhost }}:5432/{{ dbname }}"
+api_port=5000
+ws_port=5000
 
 [clients]
 <add_client_hosts>
-
-[clients:vars]
-api_host=<server_api_host>
-api_port=<server_api_port>
 
 [workers]
 <add_worker_hosts>
 
 [workers:vars]
-ws_url=ws://<server_host>:<server_port>
+server_host="{{ groups['servers'][0] }}"
+ws_port="{{ hostvars[groups['servers'][0]].ws_port }}"
+ws_url="ws://{{ server_host }}:{{ ws_port }}"

--- a/ci/ansible/server.yml
+++ b/ci/ansible/server.yml
@@ -1,17 +1,14 @@
 - hosts: servers
-  become: yes
 
   vars:
-    - buildDir: "/etc/opt"
-    - appDir: "{{ buildDir }}/herbert"
-    - nodejs_version: "14.x"
-    - nodejs_package_json_path: "{{appDir}}"
-    - service_description: "Main server for the herbert system"
+    - nodejs_version: '14.x'
+    - service_description: 'Main server for the herbert system'
     - service_user: root
     - service_file: dist/server/main.js
 
   tasks:
     - name: Install System Dependencies
+      become: yes
       apt: name={{ item }} update_cache=yes state=latest
       with_items:
         - git
@@ -19,31 +16,60 @@
         - g++
         - make
 
-    - name: Git Clone Repo
-      become: no
-      when: herbert_version != "local"
-      git:
-        repo: https://github.com/metatooth/herbert.git
-        dest: "{{appDir}}"
-        version: "{{herbert_version}}"
-        force: yes
+    - name: Create {{ appDir }}
+      file:
+        path: '{{ appDir }}'
+        state: directory
 
-    - name: Sync local herbert repo
-      become: no
-      when: herbert_version == "local"
+    - name: Create {{ appDir }}/dist
+      file:
+        path: '{{ appDir }}/dist'
+        state: directory
+
+    - name: Sync herbert dist
       synchronize:
-        src: ../../../herbert
-        dest: "{{buildDir}}"
+        src: '{{ distDir }}/server'
+        dest: '{{ appDir }}/dist'
+        recursive: yes
+        delete: yes
 
-    - name: Install nodejs {{nodejs_version}} and node_modules
+    - name: Sync herbert shared
+      synchronize:
+        src: '{{ distDir }}/shared'
+        dest: '{{ appDir }}/dist'
+        recursive: yes
+        delete: yes
+
+    - name: Sync herbert config
+      synchronize:
+        src: '{{ srcDir }}/config'
+        dest: '{{ appDir }}'
+        recursive: yes
+        delete: yes
+
+    - name: Sync herbert package.json
+      synchronize:
+        src: '{{ srcDir }}/package.json'
+        dest: '{{ appDir }}'
+
+    - name: Sync herbert package-lock.json
+      synchronize:
+        src: '{{ srcDir }}/package-lock.json'
+        dest: '{{ appDir }}'
+
+    - name: Install nodejs {{nodejs_version}}
       include_role:
         name: geerlingguy.nodejs
 
-    - name: Build server
-      become: no
-      command: "chdir={{appDir}} npm run build:server"
+    - name: Install production node_modules
+      command: npm install
+      args:
+        chdir: '{{ appDir }}'
+      environment:
+        NODE_ENV: production
 
     - name: Install server service
+      become: yes
       template:
         src: ./templates/systemd-service.j2
         dest: /etc/systemd/system/herbert-server.service
@@ -52,6 +78,7 @@
         mode: '0644'
 
     - name: Enable and start herbert-server service
+      become: yes
       systemd:
         name: herbert-server
         state: restarted

--- a/ci/ansible/worker.yml
+++ b/ci/ansible/worker.yml
@@ -1,18 +1,14 @@
 - hosts: workers
-  become: yes
 
   vars:
-    - buildDir: "/etc/opt"
-    - appDir: "{{buildDir}}/herbert"
-    - nodejs_version: "14.x"
-    - nodejs_package_json_path: "{{appDir}}"
-    - service_description: "Herbert in-room worker service"
+    - nodejs_version: '14.x'
+    - service_description: 'Herbert in-room worker service'
     - service_user: root
     - service_file: dist/worker/main.js
-    - node_env: "{{config_name}}"
 
   tasks:
     - name: Install System Dependencies
+      become: yes
       apt: name={{ item }} update_cache=yes state=latest
       with_items:
         - bluetooth
@@ -24,33 +20,60 @@
         - g++
         - make
 
-    - name: Git Clone Repo
-      become: no
-      when: herbert_version != "local"
-      git:
-        repo: https://github.com/metatooth/herbert.git
-        dest: "{{appDir}}"
-        version: "{{herbert_version}}"
-        force: yes
+    - name: Create {{ appDir }}
+      file:
+        path: '{{ appDir }}'
+        state: directory
 
-    - name: Sync local herbert repo
-      become: no
-      when: herbert_version == "local"
+    - name: Create {{ appDir }}/dist
+      file:
+        path: '{{ appDir }}/dist'
+        state: directory
+
+    - name: Sync herbert dist
       synchronize:
-        src: ../../../herbert
-        dest: "{{buildDir}}"
+        src: '{{ distDir }}/worker'
+        dest: '{{ appDir }}/dist'
+        recursive: yes
+        delete: yes
 
-    - name: Install nodejs {{nodejs_version}} and node_modules
-      when: herbert_version != "local"
+    - name: Sync herbert shared
+      synchronize:
+        src: '{{ distDir }}/shared'
+        dest: '{{ appDir }}/dist'
+        recursive: yes
+        delete: yes
+
+    - name: Sync herbert config
+      synchronize:
+        src: '{{ srcDir }}/config'
+        dest: '{{ appDir }}'
+        recursive: yes
+        delete: yes
+
+    - name: Sync herbert package.json
+      synchronize:
+        src: '{{ srcDir }}/package.json'
+        dest: '{{ appDir }}'
+
+    - name: Sync herbert package-lock.json
+      synchronize:
+        src: '{{ srcDir }}/package-lock.json'
+        dest: '{{ appDir }}'
+
+    - name: Install nodejs {{nodejs_version}}
       include_role:
         name: geerlingguy.nodejs
 
-    - name: Build worker
-      become: no
-      when: herbert_version != "local"
-      command: "chdir={{appDir}} npm run build:worker"
+    - name: Install production node_modules
+      command: npm install
+      args:
+        chdir: '{{ appDir }}'
+      environment:
+        NODE_ENV: production
 
     - name: Install worker service
+      become: yes
       template:
         src: ./templates/systemd-service.j2
         dest: /etc/systemd/system/herbert-worker.service
@@ -59,6 +82,7 @@
         mode: '0644'
 
     - name: Enable and start herbert-worker service
+      become: yes
       systemd:
         name: herbert-worker
         state: restarted

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,5 @@
 {
   "polling": 5,
   "interval": 30,
-  "reporting-period": 180,
-  "ws-url": "ws://localhost:5000"
+  "reporting-period": 180
 }

--- a/config/test.json
+++ b/config/test.json
@@ -3,7 +3,6 @@
   "port": 4300,
   "polling": 3,
   "interval": 30,
-  "ws-url": "ws://localhost:8080",
   "intake-meter": "aaaaaaaaaaaa",
   "main-meter": "bbbbbbbbbbbb",
   "environment": {


### PR DESCRIPTION
This helps cut down on the amount of memory needed on the nodes,
especially when building the client.